### PR TITLE
Add EF Core entity configuration classes

### DIFF
--- a/Infrastructure/Data/ApplicationDbContext.cs
+++ b/Infrastructure/Data/ApplicationDbContext.cs
@@ -21,23 +21,7 @@ namespace HospitalManagementSystem.Infrastructure.Data
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             base.OnModelCreating(modelBuilder);
-
-            // Apply configurations
-            modelBuilder.ApplyConfiguration(new PatientConfiguration());
-            modelBuilder.ApplyConfiguration(new DoctorConfiguration());
-            modelBuilder.ApplyConfiguration(new MedicalRecordConfiguration());
-            modelBuilder.ApplyConfiguration(new AppointmentConfiguration());
-            modelBuilder.ApplyConfiguration(new MedicationConfiguration());
-            modelBuilder.ApplyConfiguration(new PrescriptionConfiguration());
-            modelBuilder.ApplyConfiguration(new BillingConfiguration());
-            modelBuilder.ApplyConfiguration(new RoomConfiguration());
-            modelBuilder.ApplyConfiguration(new StaffConfiguration());
-            modelBuilder.ApplyConfiguration(new DepartmentConfiguration());
-
-            // Apply soft delete filter
-            modelBuilder.Entity<Patient>().HasQueryFilter(p => p.IsActive);
-            modelBuilder.Entity<Doctor>().HasQueryFilter(d => d.Status == "Active");
-            modelBuilder.Entity<Staff>().HasQueryFilter(s => s.Status == "Active");
+            modelBuilder.ApplyConfigurationsFromAssembly(typeof(ApplicationDbContext).Assembly);
         }
 
         public override async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)

--- a/Infrastructure/Data/Configurations/AppointmentConfiguration.cs
+++ b/Infrastructure/Data/Configurations/AppointmentConfiguration.cs
@@ -1,0 +1,13 @@
+using HospitalManagementSystem.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HospitalManagementSystem.Infrastructure.Data.Configurations;
+
+public class AppointmentConfiguration : IEntityTypeConfiguration<Appointment>
+{
+    public void Configure(EntityTypeBuilder<Appointment> builder)
+    {
+        builder.HasKey(a => a.AppointmentId);
+    }
+}

--- a/Infrastructure/Data/Configurations/BillingConfiguration.cs
+++ b/Infrastructure/Data/Configurations/BillingConfiguration.cs
@@ -1,0 +1,13 @@
+using HospitalManagementSystem.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HospitalManagementSystem.Infrastructure.Data.Configurations;
+
+public class BillingConfiguration : IEntityTypeConfiguration<Billing>
+{
+    public void Configure(EntityTypeBuilder<Billing> builder)
+    {
+        builder.HasKey(b => b.BillId);
+    }
+}

--- a/Infrastructure/Data/Configurations/DepartmentConfiguration.cs
+++ b/Infrastructure/Data/Configurations/DepartmentConfiguration.cs
@@ -1,0 +1,13 @@
+using HospitalManagementSystem.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HospitalManagementSystem.Infrastructure.Data.Configurations;
+
+public class DepartmentConfiguration : IEntityTypeConfiguration<Department>
+{
+    public void Configure(EntityTypeBuilder<Department> builder)
+    {
+        builder.HasKey(d => d.DepartmentId);
+    }
+}

--- a/Infrastructure/Data/Configurations/DoctorConfiguration.cs
+++ b/Infrastructure/Data/Configurations/DoctorConfiguration.cs
@@ -1,0 +1,14 @@
+using HospitalManagementSystem.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HospitalManagementSystem.Infrastructure.Data.Configurations;
+
+public class DoctorConfiguration : IEntityTypeConfiguration<Doctor>
+{
+    public void Configure(EntityTypeBuilder<Doctor> builder)
+    {
+        builder.HasKey(d => d.DoctorId);
+        builder.HasQueryFilter(d => d.Status == "Active");
+    }
+}

--- a/Infrastructure/Data/Configurations/MedicalRecordConfiguration.cs
+++ b/Infrastructure/Data/Configurations/MedicalRecordConfiguration.cs
@@ -1,0 +1,13 @@
+using HospitalManagementSystem.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HospitalManagementSystem.Infrastructure.Data.Configurations;
+
+public class MedicalRecordConfiguration : IEntityTypeConfiguration<MedicalRecord>
+{
+    public void Configure(EntityTypeBuilder<MedicalRecord> builder)
+    {
+        builder.HasKey(m => m.RecordId);
+    }
+}

--- a/Infrastructure/Data/Configurations/MedicationConfiguration.cs
+++ b/Infrastructure/Data/Configurations/MedicationConfiguration.cs
@@ -1,0 +1,13 @@
+using HospitalManagementSystem.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HospitalManagementSystem.Infrastructure.Data.Configurations;
+
+public class MedicationConfiguration : IEntityTypeConfiguration<Medication>
+{
+    public void Configure(EntityTypeBuilder<Medication> builder)
+    {
+        builder.HasKey(m => m.MedicationId);
+    }
+}

--- a/Infrastructure/Data/Configurations/PatientConfiguration.cs
+++ b/Infrastructure/Data/Configurations/PatientConfiguration.cs
@@ -1,0 +1,14 @@
+using HospitalManagementSystem.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HospitalManagementSystem.Infrastructure.Data.Configurations;
+
+public class PatientConfiguration : IEntityTypeConfiguration<Patient>
+{
+    public void Configure(EntityTypeBuilder<Patient> builder)
+    {
+        builder.HasKey(p => p.PatientId);
+        builder.HasQueryFilter(p => p.IsActive);
+    }
+}

--- a/Infrastructure/Data/Configurations/PrescriptionConfiguration.cs
+++ b/Infrastructure/Data/Configurations/PrescriptionConfiguration.cs
@@ -1,0 +1,13 @@
+using HospitalManagementSystem.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HospitalManagementSystem.Infrastructure.Data.Configurations;
+
+public class PrescriptionConfiguration : IEntityTypeConfiguration<Prescription>
+{
+    public void Configure(EntityTypeBuilder<Prescription> builder)
+    {
+        builder.HasKey(p => p.PrescriptionId);
+    }
+}

--- a/Infrastructure/Data/Configurations/RoomConfiguration.cs
+++ b/Infrastructure/Data/Configurations/RoomConfiguration.cs
@@ -1,0 +1,13 @@
+using HospitalManagementSystem.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HospitalManagementSystem.Infrastructure.Data.Configurations;
+
+public class RoomConfiguration : IEntityTypeConfiguration<Room>
+{
+    public void Configure(EntityTypeBuilder<Room> builder)
+    {
+        builder.HasKey(r => r.RoomId);
+    }
+}

--- a/Infrastructure/Data/Configurations/StaffConfiguration.cs
+++ b/Infrastructure/Data/Configurations/StaffConfiguration.cs
@@ -1,0 +1,14 @@
+using HospitalManagementSystem.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HospitalManagementSystem.Infrastructure.Data.Configurations;
+
+public class StaffConfiguration : IEntityTypeConfiguration<Staff>
+{
+    public void Configure(EntityTypeBuilder<Staff> builder)
+    {
+        builder.HasKey(s => s.StaffId);
+        builder.HasQueryFilter(s => s.Status == "Active");
+    }
+}


### PR DESCRIPTION
## Summary
- add configuration classes for Patient, Doctor, MedicalRecord and other entities
- streamline DbContext to scan configuration types automatically

## Testing
- `dotnet build --no-restore` *(fails: IPatientRepository could not be found)*
- `dotnet ef migrations add TempMigration -p Infrastructure/HospitalManagementSystem.Infrastructure.csproj -s WebAPI/HospitalManagementSystem.WebAPI.csproj --context ApplicationDbContext --output-dir Data/Migrations` *(fails: Build failed)*

------
https://chatgpt.com/codex/tasks/task_e_688dafadd0d883268296bf3aa873aa97