### PR TITLE
Add missing using directives

### DIFF
--- a/Application/Features/Patients/Commands/Create/CreatePatientCommandHandler.cs
+++ b/Application/Features/Patients/Commands/Create/CreatePatientCommandHandler.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using AutoMapper;
 using MediatR;
+using Microsoft.EntityFrameworkCore;
 using HospitalManagementSystem.Application.Common.Interfaces;
 using HospitalManagementSystem.Application.DTOs;
 using HospitalManagementSystem.Domain.Entities;

--- a/Application/Features/Patients/Commands/Create/CreatePatientCommandValidator.cs
+++ b/Application/Features/Patients/Commands/Create/CreatePatientCommandValidator.cs
@@ -1,4 +1,6 @@
-﻿using FluentValidation;
+using System;
+using System.Linq;
+using FluentValidation;
 using HospitalManagementSystem.Application.Features.Patients.Commands.Create;
 
 namespace HospitalManagementSystem.Application.Features.Patients.Commands.Create;
@@ -40,3 +42,4 @@ public class CreatePatientCommandValidator : AbstractValidator<CreatePatientComm
             .MaximumLength(100).WithMessage("Emergency contact must not exceed 100 characters.");
     }
 }
+

--- a/Infrastructure/Data/Repositories/PatientRepository.cs
+++ b/Infrastructure/Data/Repositories/PatientRepository.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.EntityFrameworkCore;
 using HospitalManagementSystem.Domain.Entities;
 using HospitalManagementSystem.Domain.Interfaces;
 

--- a/WebAPI/Program.cs
+++ b/WebAPI/Program.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
+using System.Collections.Generic;
 using System.Text;
 using HospitalManagementSystem.Infrastructure.Data;
 using HospitalManagementSystem.Infrastructure.Identity;


### PR DESCRIPTION
## Summary
- include Microsoft.EntityFrameworkCore in patient command handler and repository
- import System and System.Linq in patient command validator
- ensure WebAPI Program references EF Core and generic collections

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_688dafa261c483268d856ce66245f9d6