### PR TITLE
Remove placeholder Class1 files

### DIFF
--- a/Application/Class1.cs
+++ b/Application/Class1.cs
@@ -1,6 +1,0 @@
-﻿namespace HospitalManagementSystem.Application;
-
-public class Class1
-{
-
-}

--- a/Domain/Class1.cs
+++ b/Domain/Class1.cs
@@ -1,6 +1,0 @@
-﻿namespace HospitalManagementSystem.Domain;
-
-public class Class1
-{
-
-}

--- a/Infrastructure/Class1.cs
+++ b/Infrastructure/Class1.cs
@@ -1,6 +1,0 @@
-﻿namespace HospitalManagementSystem.Infrastructure;
-
-public class Class1
-{
-
-}


### PR DESCRIPTION
## Summary
- delete unused `Class1.cs` placeholders from Application, Domain, and Infrastructure projects

## Testing
- `dotnet build` *(fails: PatientService.cs(15,69): error CS0246: The type or namespace name 'IUnitOfWork' could not be found...)*

------
https://chatgpt.com/codex/tasks/task_e_688daf9c74e08326a5da9a858cdb8f6b