### PR TITLE
Add validators for update commands

### DIFF
--- a/Application/Features/Departments/Commands/Update/UpdateDepartmentCommandValidator.cs
+++ b/Application/Features/Departments/Commands/Update/UpdateDepartmentCommandValidator.cs
@@ -1,0 +1,19 @@
+using FluentValidation;
+
+namespace HospitalManagementSystem.Application.Features.Departments.Commands.Update;
+
+public class UpdateDepartmentCommandValidator : AbstractValidator<UpdateDepartmentCommand>
+{
+    public UpdateDepartmentCommandValidator()
+    {
+        RuleFor(x => x.DepartmentId)
+            .GreaterThan(0);
+
+        RuleFor(x => x.Name)
+            .NotEmpty();
+
+        RuleFor(x => x.Location)
+            .NotEmpty();
+    }
+}
+

--- a/Application/Features/Doctors/Commands/Update/UpdateDoctorCommandValidator.cs
+++ b/Application/Features/Doctors/Commands/Update/UpdateDoctorCommandValidator.cs
@@ -1,0 +1,32 @@
+using FluentValidation;
+
+namespace HospitalManagementSystem.Application.Features.Doctors.Commands.Update;
+
+public class UpdateDoctorCommandValidator : AbstractValidator<UpdateDoctorCommand>
+{
+    public UpdateDoctorCommandValidator()
+    {
+        RuleFor(x => x.DoctorId)
+            .GreaterThan(0);
+
+        RuleFor(x => x.FirstName)
+            .NotEmpty();
+
+        RuleFor(x => x.LastName)
+            .NotEmpty();
+
+        RuleFor(x => x.Specialization)
+            .NotEmpty();
+
+        RuleFor(x => x.ContactNumber)
+            .NotEmpty();
+
+        RuleFor(x => x.DepartmentId)
+            .GreaterThan(0);
+
+        RuleFor(x => x.Email)
+            .EmailAddress()
+            .When(x => !string.IsNullOrEmpty(x.Email));
+    }
+}
+

--- a/Application/Features/Patients/Commands/Update/UpdatePatientCommandValidator.cs
+++ b/Application/Features/Patients/Commands/Update/UpdatePatientCommandValidator.cs
@@ -1,0 +1,37 @@
+using FluentValidation;
+
+namespace HospitalManagementSystem.Application.Features.Patients.Commands.Update;
+
+public class UpdatePatientCommandValidator : AbstractValidator<UpdatePatientCommand>
+{
+    public UpdatePatientCommandValidator()
+    {
+        RuleFor(v => v.PatientId)
+            .GreaterThan(0);
+
+        RuleFor(v => v.FirstName)
+            .NotEmpty().WithMessage("First name is required.")
+            .MaximumLength(50).WithMessage("First name must not exceed 50 characters.");
+
+        RuleFor(v => v.LastName)
+            .NotEmpty().WithMessage("Last name is required.")
+            .MaximumLength(50).WithMessage("Last name must not exceed 50 characters.");
+
+        RuleFor(v => v.ContactNumber)
+            .NotEmpty().WithMessage("Contact number is required.")
+            .Matches(@"^\+?[\d\s\-\(\)]+$").WithMessage("Invalid contact number format.");
+
+        RuleFor(v => v.Email)
+            .EmailAddress().WithMessage("Invalid email format.")
+            .When(v => !string.IsNullOrEmpty(v.Email));
+
+        RuleFor(v => v.Address)
+            .NotEmpty().WithMessage("Address is required.")
+            .MaximumLength(200).WithMessage("Address must not exceed 200 characters.");
+
+        RuleFor(v => v.EmergencyContact)
+            .NotEmpty().WithMessage("Emergency contact is required.")
+            .MaximumLength(100).WithMessage("Emergency contact must not exceed 100 characters.");
+    }
+}
+

--- a/Application/Features/Rooms/Commands/Update/UpdateRoomCommandValidator.cs
+++ b/Application/Features/Rooms/Commands/Update/UpdateRoomCommandValidator.cs
@@ -1,0 +1,28 @@
+using FluentValidation;
+
+namespace HospitalManagementSystem.Application.Features.Rooms.Commands.Update;
+
+public class UpdateRoomCommandValidator : AbstractValidator<UpdateRoomCommand>
+{
+    public UpdateRoomCommandValidator()
+    {
+        RuleFor(x => x.RoomId)
+            .GreaterThan(0);
+
+        RuleFor(x => x.RoomNumber)
+            .NotEmpty();
+
+        RuleFor(x => x.RoomTypeId)
+            .GreaterThan(0);
+
+        RuleFor(x => x.DepartmentId)
+            .GreaterThan(0);
+
+        RuleFor(x => x.Capacity)
+            .GreaterThan(0);
+
+        RuleFor(x => x.CurrentOccupancy)
+            .GreaterThanOrEqualTo(0);
+    }
+}
+

--- a/Application/Features/Staff/Commands/Update/UpdateStaffCommandValidator.cs
+++ b/Application/Features/Staff/Commands/Update/UpdateStaffCommandValidator.cs
@@ -1,0 +1,56 @@
+using FluentValidation;
+
+namespace HospitalManagementSystem.Application.Features.Staff.Commands.Update;
+
+public class UpdateStaffCommandValidator : AbstractValidator<UpdateStaffCommand>
+{
+    public UpdateStaffCommandValidator()
+    {
+        RuleFor(x => x.StaffId)
+            .GreaterThan(0);
+
+        RuleFor(x => x.FirstName)
+            .NotEmpty();
+
+        RuleFor(x => x.LastName)
+            .NotEmpty();
+
+        RuleFor(x => x.Position)
+            .NotEmpty();
+
+        RuleFor(x => x.EmployeeId)
+            .NotEmpty();
+
+        RuleFor(x => x.DepartmentId)
+            .GreaterThan(0);
+
+        RuleFor(x => x.ContactNumber)
+            .NotEmpty();
+
+        RuleFor(x => x.Address)
+            .NotEmpty();
+
+        RuleFor(x => x.DateOfBirth)
+            .NotEmpty();
+
+        RuleFor(x => x.HireDate)
+            .NotEmpty();
+
+        RuleFor(x => x.EmploymentType)
+            .NotEmpty();
+
+        RuleFor(x => x.Salary)
+            .GreaterThan(0);
+
+        RuleFor(x => x.Shift)
+            .NotEmpty();
+
+        RuleFor(x => x.WorkingHours)
+            .NotEmpty();
+
+        RuleFor(x => x.Email)
+            .EmailAddress()
+            .When(x => !string.IsNullOrEmpty(x.Email));
+    }
+}
+


### PR DESCRIPTION
## Summary
- add FluentValidation validators for patient, doctor, department, room, and staff update commands
- validators ensure IDs and key fields are present and valid

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_688dbae785108326a01f24761ed8b4ee