### PR TITLE
Implement current user service for auditing

### DIFF
--- a/Application/Common/Interfaces/ICurrentUserService.cs
+++ b/Application/Common/Interfaces/ICurrentUserService.cs
@@ -1,0 +1,6 @@
+namespace HospitalManagementSystem.Application.Common.Interfaces;
+
+public interface ICurrentUserService
+{
+    string? UserName { get; }
+}

--- a/Infrastructure/Data/ApplicationDbContext.cs
+++ b/Infrastructure/Data/ApplicationDbContext.cs
@@ -1,11 +1,18 @@
-﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 using HospitalManagementSystem.Domain.Entities;
+using HospitalManagementSystem.Application.Common.Interfaces;
 
 namespace HospitalManagementSystem.Infrastructure.Data
 {
     public class ApplicationDbContext : DbContext
     {
-        public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : base(options) { }
+        private readonly ICurrentUserService _currentUserService;
+
+        public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options, ICurrentUserService currentUserService)
+            : base(options)
+        {
+            _currentUserService = currentUserService;
+        }
 
         public DbSet<Patient> Patients { get; set; }
         public DbSet<Doctor> Doctors { get; set; }
@@ -28,19 +35,21 @@ namespace HospitalManagementSystem.Infrastructure.Data
         {
             // Add timestamps
             var entries = ChangeTracker.Entries<BaseEntity>();
-            
+
             foreach (var entry in entries)
             {
+                var userName = _currentUserService.UserName ?? "System";
+
                 if (entry.State == EntityState.Added)
                 {
                     entry.Entity.CreatedAt = DateTime.UtcNow;
-                    entry.Entity.CreatedBy = "System"; // Replace with current user
+                    entry.Entity.CreatedBy = userName;
                 }
-                
+
                 if (entry.State == EntityState.Modified)
                 {
                     entry.Entity.UpdatedAt = DateTime.UtcNow;
-                    entry.Entity.UpdatedBy = "System"; // Replace with current user
+                    entry.Entity.UpdatedBy = userName;
                 }
             }
 

--- a/WebAPI/Program.cs
+++ b/WebAPI/Program.cs
@@ -7,11 +7,15 @@ using System.Text;
 using HospitalManagementSystem.Infrastructure.Data;
 using HospitalManagementSystem.Infrastructure.Identity;
 using HospitalManagementSystem.WebAPI.Middleware;
+using HospitalManagementSystem.Application.Common.Interfaces;
+using HospitalManagementSystem.WebAPI.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 builder.Services.AddControllers();
+builder.Services.AddHttpContextAccessor();
+builder.Services.AddScoped<ICurrentUserService, CurrentUserService>();
 
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();

--- a/WebAPI/Services/CurrentUserService.cs
+++ b/WebAPI/Services/CurrentUserService.cs
@@ -1,0 +1,16 @@
+using HospitalManagementSystem.Application.Common.Interfaces;
+using Microsoft.AspNetCore.Http;
+
+namespace HospitalManagementSystem.WebAPI.Services;
+
+public class CurrentUserService : ICurrentUserService
+{
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public CurrentUserService(IHttpContextAccessor httpContextAccessor)
+    {
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public string? UserName => _httpContextAccessor.HttpContext?.User?.Identity?.Name;
+}


### PR DESCRIPTION
## Summary
- add `ICurrentUserService` interface to expose current username
- implement `CurrentUserService` in WebAPI and register with DI
- use `ICurrentUserService` in `ApplicationDbContext` to populate `CreatedBy` and `UpdatedBy`

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688dbae4e64c8326b011eb6baea70f53