### PR TITLE
feat: add appointment update and delete commands

### DIFF
--- a/Application/Common/Mappings/MappingProfile.cs
+++ b/Application/Common/Mappings/MappingProfile.cs
@@ -1,6 +1,7 @@
 ﻿using AutoMapper;
 using HospitalManagementSystem.Application.DTOs;
 using HospitalManagementSystem.Application.Features.Appointments.Commands.Create;
+using HospitalManagementSystem.Application.Features.Appointments.Commands.Update;
 using HospitalManagementSystem.Application.Features.MedicalRecords.Commands;
 using HospitalManagementSystem.Application.Features.Patients.Commands.Create;
 using HospitalManagementSystem.Application.Features.Patients.Commands.Update;
@@ -41,6 +42,7 @@ public class MappingProfile : Profile
             .ForMember(dest => dest.RoomNumber, opt => opt.MapFrom(src => src.Room != null ? src.Room.RoomNumber : null));
 
         CreateMap<CreateAppointmentCommand, Appointment>();
+        CreateMap<UpdateAppointmentCommand, Appointment>();
 
         // Doctor mappings
         CreateMap<Doctor, DoctorDto>()

--- a/Application/Features/Appointments/Commands/Delete/DeleteAppointmentCommand.cs
+++ b/Application/Features/Appointments/Commands/Delete/DeleteAppointmentCommand.cs
@@ -1,0 +1,9 @@
+using HospitalManagementSystem.Application.Common.Models;
+
+namespace HospitalManagementSystem.Application.Features.Appointments.Commands.Delete;
+
+public class DeleteAppointmentCommand : BaseCommand
+{
+    public int AppointmentId { get; set; }
+}
+

--- a/Application/Features/Appointments/Commands/Delete/DeleteAppointmentCommandHandler.cs
+++ b/Application/Features/Appointments/Commands/Delete/DeleteAppointmentCommandHandler.cs
@@ -1,0 +1,30 @@
+using HospitalManagementSystem.Application.Common.Interfaces;
+using HospitalManagementSystem.Domain.Exceptions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace HospitalManagementSystem.Application.Features.Appointments.Commands.Delete;
+
+public class DeleteAppointmentCommandHandler : IRequestHandler<DeleteAppointmentCommand>
+{
+    private readonly IApplicationDbContext _context;
+
+    public DeleteAppointmentCommandHandler(IApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task Handle(DeleteAppointmentCommand request, CancellationToken cancellationToken)
+    {
+        var appointment = await _context.Appointments
+            .FirstOrDefaultAsync(a => a.AppointmentId == request.AppointmentId, cancellationToken);
+        if (appointment == null)
+        {
+            throw new NotFoundException("Appointment", request.AppointmentId);
+        }
+
+        _context.Appointments.Remove(appointment);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+}
+

--- a/Application/Features/Appointments/Commands/Update/UpdateAppointmentCommand.cs
+++ b/Application/Features/Appointments/Commands/Update/UpdateAppointmentCommand.cs
@@ -1,0 +1,17 @@
+using HospitalManagementSystem.Application.Common.Models;
+
+namespace HospitalManagementSystem.Application.Features.Appointments.Commands.Update;
+
+public class UpdateAppointmentCommand : BaseCommand
+{
+    public int AppointmentId { get; set; }
+    public int PatientId { get; set; }
+    public int DoctorId { get; set; }
+    public DateTime AppointmentDate { get; set; }
+    public DateTime EndTime { get; set; }
+    public string Status { get; set; }
+    public string Purpose { get; set; }
+    public string Notes { get; set; }
+    public int? RoomId { get; set; }
+}
+

--- a/Application/Features/Appointments/Commands/Update/UpdateAppointmentCommandHandler.cs
+++ b/Application/Features/Appointments/Commands/Update/UpdateAppointmentCommandHandler.cs
@@ -1,0 +1,33 @@
+using AutoMapper;
+using HospitalManagementSystem.Application.Common.Interfaces;
+using HospitalManagementSystem.Domain.Exceptions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace HospitalManagementSystem.Application.Features.Appointments.Commands.Update;
+
+public class UpdateAppointmentCommandHandler : IRequestHandler<UpdateAppointmentCommand>
+{
+    private readonly IApplicationDbContext _context;
+    private readonly IMapper _mapper;
+
+    public UpdateAppointmentCommandHandler(IApplicationDbContext context, IMapper mapper)
+    {
+        _context = context;
+        _mapper = mapper;
+    }
+
+    public async Task Handle(UpdateAppointmentCommand request, CancellationToken cancellationToken)
+    {
+        var appointment = await _context.Appointments
+            .FirstOrDefaultAsync(a => a.AppointmentId == request.AppointmentId, cancellationToken);
+        if (appointment == null)
+        {
+            throw new NotFoundException("Appointment", request.AppointmentId);
+        }
+
+        _mapper.Map(request, appointment);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add command to update appointments and handler to persist changes
- add command to delete appointments with handler validation
- map UpdateAppointmentCommand to Appointment entity

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*


------
https://chatgpt.com/codex/tasks/task_e_688dbad9810c83268c4f26c883c9eb4a