### PR TITLE
feat: add controllers for core domains

### DIFF
--- a/WebAPI/Controllers/AppointmentsController.cs
+++ b/WebAPI/Controllers/AppointmentsController.cs
@@ -1,0 +1,49 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using MediatR;
+using HospitalManagementSystem.Application.Features.Appointments.Commands;
+using HospitalManagementSystem.Application.Features.Appointments.Queries;
+using HospitalManagementSystem.Application.DTOs;
+
+namespace HospitalManagementSystem.WebAPI.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    [Authorize]
+    public class AppointmentsController : ControllerBase
+    {
+        private readonly IMediator _mediator;
+
+        public AppointmentsController(IMediator mediator)
+        {
+            _mediator = mediator;
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<AppointmentDto>>> GetAppointments()
+        {
+            var appointments = await _mediator.Send(new GetAllAppointmentsQuery());
+            return Ok(appointments);
+        }
+
+        [HttpGet("{id}")]
+        public async Task<ActionResult<AppointmentDto>> GetAppointment(int id)
+        {
+            var appointment = await _mediator.Send(new GetAppointmentByIdQuery { AppointmentId = id });
+            if (appointment == null)
+            {
+                return NotFound();
+            }
+            return Ok(appointment);
+        }
+
+        [HttpPost]
+        public async Task<ActionResult<int>> CreateAppointment([FromBody] CreateAppointmentCommand command)
+        {
+            var appointmentId = await _mediator.Send(command);
+            return CreatedAtAction(nameof(GetAppointment), new { id = appointmentId }, appointmentId);
+        }
+    }
+}

--- a/WebAPI/Controllers/BillingController.cs
+++ b/WebAPI/Controllers/BillingController.cs
@@ -1,0 +1,49 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using MediatR;
+using HospitalManagementSystem.Application.Features.Billing.Commands;
+using HospitalManagementSystem.Application.Features.Billing.Queries;
+using HospitalManagementSystem.Application.DTOs;
+
+namespace HospitalManagementSystem.WebAPI.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    [Authorize]
+    public class BillingController : ControllerBase
+    {
+        private readonly IMediator _mediator;
+
+        public BillingController(IMediator mediator)
+        {
+            _mediator = mediator;
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<BillingDto>>> GetBillings()
+        {
+            var billings = await _mediator.Send(new GetAllBillingsQuery());
+            return Ok(billings);
+        }
+
+        [HttpGet("{id}")]
+        public async Task<ActionResult<BillingDto>> GetBilling(int id)
+        {
+            var billing = await _mediator.Send(new GetBillingByIdQuery { BillingId = id });
+            if (billing == null)
+            {
+                return NotFound();
+            }
+            return Ok(billing);
+        }
+
+        [HttpPost]
+        public async Task<ActionResult<PaymentResultDto>> ProcessPayment([FromBody] ProcessPaymentCommand command)
+        {
+            var result = await _mediator.Send(command);
+            return Ok(result);
+        }
+    }
+}

--- a/WebAPI/Controllers/DepartmentsController.cs
+++ b/WebAPI/Controllers/DepartmentsController.cs
@@ -1,0 +1,69 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using MediatR;
+using HospitalManagementSystem.Application.Features.Departments.Commands;
+using HospitalManagementSystem.Application.Features.Departments.Queries;
+using HospitalManagementSystem.Application.DTOs;
+
+namespace HospitalManagementSystem.WebAPI.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    [Authorize]
+    public class DepartmentsController : ControllerBase
+    {
+        private readonly IMediator _mediator;
+
+        public DepartmentsController(IMediator mediator)
+        {
+            _mediator = mediator;
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<DepartmentDto>>> GetDepartments()
+        {
+            var departments = await _mediator.Send(new GetAllDepartmentsQuery());
+            return Ok(departments);
+        }
+
+        [HttpGet("{id}")]
+        public async Task<ActionResult<DepartmentDto>> GetDepartment(int id)
+        {
+            var department = await _mediator.Send(new GetDepartmentByIdQuery { DepartmentId = id });
+            if (department == null)
+            {
+                return NotFound();
+            }
+            return Ok(department);
+        }
+
+        [HttpPost]
+        public async Task<ActionResult<int>> CreateDepartment([FromBody] CreateDepartmentCommand command)
+        {
+            var departmentId = await _mediator.Send(command);
+            return CreatedAtAction(nameof(GetDepartment), new { id = departmentId }, departmentId);
+        }
+
+        [HttpPut("{id}")]
+        public async Task<IActionResult> UpdateDepartment(int id, [FromBody] UpdateDepartmentCommand command)
+        {
+            if (id != command.DepartmentId)
+            {
+                return BadRequest();
+            }
+
+            await _mediator.Send(command);
+            return NoContent();
+        }
+
+        [HttpDelete("{id}")]
+        [Authorize(Roles = "Administrator")]
+        public async Task<IActionResult> DeleteDepartment(int id)
+        {
+            await _mediator.Send(new DeleteDepartmentCommand { DepartmentId = id });
+            return NoContent();
+        }
+    }
+}

--- a/WebAPI/Controllers/DoctorsController.cs
+++ b/WebAPI/Controllers/DoctorsController.cs
@@ -1,0 +1,69 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using MediatR;
+using HospitalManagementSystem.Application.Features.Doctors.Commands;
+using HospitalManagementSystem.Application.Features.Doctors.Queries;
+using HospitalManagementSystem.Application.DTOs;
+
+namespace HospitalManagementSystem.WebAPI.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    [Authorize]
+    public class DoctorsController : ControllerBase
+    {
+        private readonly IMediator _mediator;
+
+        public DoctorsController(IMediator mediator)
+        {
+            _mediator = mediator;
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<DoctorDto>>> GetDoctors()
+        {
+            var doctors = await _mediator.Send(new GetAllDoctorsQuery());
+            return Ok(doctors);
+        }
+
+        [HttpGet("{id}")]
+        public async Task<ActionResult<DoctorDto>> GetDoctor(int id)
+        {
+            var doctor = await _mediator.Send(new GetDoctorByIdQuery { DoctorId = id });
+            if (doctor == null)
+            {
+                return NotFound();
+            }
+            return Ok(doctor);
+        }
+
+        [HttpPost]
+        public async Task<ActionResult<int>> CreateDoctor([FromBody] CreateDoctorCommand command)
+        {
+            var doctorId = await _mediator.Send(command);
+            return CreatedAtAction(nameof(GetDoctor), new { id = doctorId }, doctorId);
+        }
+
+        [HttpPut("{id}")]
+        public async Task<IActionResult> UpdateDoctor(int id, [FromBody] UpdateDoctorCommand command)
+        {
+            if (id != command.DoctorId)
+            {
+                return BadRequest();
+            }
+
+            await _mediator.Send(command);
+            return NoContent();
+        }
+
+        [HttpDelete("{id}")]
+        [Authorize(Roles = "Administrator")]
+        public async Task<IActionResult> DeleteDoctor(int id)
+        {
+            await _mediator.Send(new DeleteDoctorCommand { DoctorId = id });
+            return NoContent();
+        }
+    }
+}

--- a/WebAPI/Controllers/MedicalRecordsController.cs
+++ b/WebAPI/Controllers/MedicalRecordsController.cs
@@ -1,0 +1,49 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using MediatR;
+using HospitalManagementSystem.Application.Features.MedicalRecords.Commands;
+using HospitalManagementSystem.Application.Features.MedicalRecords.Queries;
+using HospitalManagementSystem.Application.DTOs;
+
+namespace HospitalManagementSystem.WebAPI.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    [Authorize]
+    public class MedicalRecordsController : ControllerBase
+    {
+        private readonly IMediator _mediator;
+
+        public MedicalRecordsController(IMediator mediator)
+        {
+            _mediator = mediator;
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<MedicalRecordDto>>> GetMedicalRecords()
+        {
+            var records = await _mediator.Send(new GetAllMedicalRecordsQuery());
+            return Ok(records);
+        }
+
+        [HttpGet("{id}")]
+        public async Task<ActionResult<MedicalRecordDto>> GetMedicalRecord(int id)
+        {
+            var record = await _mediator.Send(new GetMedicalRecordByIdQuery { RecordId = id });
+            if (record == null)
+            {
+                return NotFound();
+            }
+            return Ok(record);
+        }
+
+        [HttpPost]
+        public async Task<ActionResult<int>> CreateMedicalRecord([FromBody] CreateMedicalRecordCommand command)
+        {
+            var recordId = await _mediator.Send(command);
+            return CreatedAtAction(nameof(GetMedicalRecord), new { id = recordId }, recordId);
+        }
+    }
+}

--- a/WebAPI/Controllers/RoomsController.cs
+++ b/WebAPI/Controllers/RoomsController.cs
@@ -1,0 +1,69 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using MediatR;
+using HospitalManagementSystem.Application.Features.Rooms.Commands;
+using HospitalManagementSystem.Application.Features.Rooms.Queries;
+using HospitalManagementSystem.Application.DTOs;
+
+namespace HospitalManagementSystem.WebAPI.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    [Authorize]
+    public class RoomsController : ControllerBase
+    {
+        private readonly IMediator _mediator;
+
+        public RoomsController(IMediator mediator)
+        {
+            _mediator = mediator;
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<RoomDto>>> GetRooms()
+        {
+            var rooms = await _mediator.Send(new GetAllRoomsQuery());
+            return Ok(rooms);
+        }
+
+        [HttpGet("{id}")]
+        public async Task<ActionResult<RoomDto>> GetRoom(int id)
+        {
+            var room = await _mediator.Send(new GetRoomByIdQuery { RoomId = id });
+            if (room == null)
+            {
+                return NotFound();
+            }
+            return Ok(room);
+        }
+
+        [HttpPost]
+        public async Task<ActionResult<int>> CreateRoom([FromBody] CreateRoomCommand command)
+        {
+            var roomId = await _mediator.Send(command);
+            return CreatedAtAction(nameof(GetRoom), new { id = roomId }, roomId);
+        }
+
+        [HttpPut("{id}")]
+        public async Task<IActionResult> UpdateRoom(int id, [FromBody] UpdateRoomCommand command)
+        {
+            if (id != command.RoomId)
+            {
+                return BadRequest();
+            }
+
+            await _mediator.Send(command);
+            return NoContent();
+        }
+
+        [HttpDelete("{id}")]
+        [Authorize(Roles = "Administrator")]
+        public async Task<IActionResult> DeleteRoom(int id)
+        {
+            await _mediator.Send(new DeleteRoomCommand { RoomId = id });
+            return NoContent();
+        }
+    }
+}

--- a/WebAPI/Controllers/StaffController.cs
+++ b/WebAPI/Controllers/StaffController.cs
@@ -1,0 +1,69 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using MediatR;
+using HospitalManagementSystem.Application.Features.Staff.Commands;
+using HospitalManagementSystem.Application.Features.Staff.Queries;
+using HospitalManagementSystem.Application.DTOs;
+
+namespace HospitalManagementSystem.WebAPI.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    [Authorize]
+    public class StaffController : ControllerBase
+    {
+        private readonly IMediator _mediator;
+
+        public StaffController(IMediator mediator)
+        {
+            _mediator = mediator;
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<StaffDto>>> GetStaff()
+        {
+            var staff = await _mediator.Send(new GetAllStaffQuery());
+            return Ok(staff);
+        }
+
+        [HttpGet("{id}")]
+        public async Task<ActionResult<StaffDto>> GetStaffMember(int id)
+        {
+            var staffMember = await _mediator.Send(new GetStaffByIdQuery { StaffId = id });
+            if (staffMember == null)
+            {
+                return NotFound();
+            }
+            return Ok(staffMember);
+        }
+
+        [HttpPost]
+        public async Task<ActionResult<int>> CreateStaff([FromBody] CreateStaffCommand command)
+        {
+            var staffId = await _mediator.Send(command);
+            return CreatedAtAction(nameof(GetStaffMember), new { id = staffId }, staffId);
+        }
+
+        [HttpPut("{id}")]
+        public async Task<IActionResult> UpdateStaff(int id, [FromBody] UpdateStaffCommand command)
+        {
+            if (id != command.StaffId)
+            {
+                return BadRequest();
+            }
+
+            await _mediator.Send(command);
+            return NoContent();
+        }
+
+        [HttpDelete("{id}")]
+        [Authorize(Roles = "Administrator")]
+        public async Task<IActionResult> DeleteStaff(int id)
+        {
+            await _mediator.Send(new DeleteStaffCommand { StaffId = id });
+            return NoContent();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Appointments controller to expose appointment queries and creation
- implement Doctors controller with full CRUD operations
- include controllers for Departments, Billing, Medical Records, Rooms, and Staff using MediatR

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_688dbaecd0a883268167bd5e9cf6f0fe