### PR TITLE
Add unit tests for patient handler and test scaffolding

### DIFF
--- a/Domain/Exceptions/DuplicateEntityException.cs
+++ b/Domain/Exceptions/DuplicateEntityException.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace HospitalManagementSystem.Domain.Exceptions
+{
+    public class DuplicateEntityException : Exception
+    {
+        public DuplicateEntityException(string entityName, string fieldName, string fieldValue)
+            : base($"{entityName} with {fieldName} '{fieldValue}' already exists.")
+        {
+        }
+    }
+}

--- a/Infrastructure/Data/DatabaseInitializer.cs
+++ b/Infrastructure/Data/DatabaseInitializer.cs
@@ -1,0 +1,12 @@
+using System.Threading.Tasks;
+
+namespace HospitalManagementSystem.Infrastructure.Data
+{
+    public class DatabaseInitializer
+    {
+        public Task InitializeAsync()
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Tests/IntegrationTests/HospitalManagementSystem.IntegrationTests/HospitalManagementSystem.IntegrationTests.csproj
+++ b/Tests/IntegrationTests/HospitalManagementSystem.IntegrationTests/HospitalManagementSystem.IntegrationTests.csproj
@@ -9,6 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="FluentAssertions" Version="8.5.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
@@ -16,6 +18,10 @@
 
   <ItemGroup>
     <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\WebAPI\HospitalManagementSystem.WebAPI.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Tests/IntegrationTests/HospitalManagementSystem.IntegrationTests/PatientsEndpointTests.cs
+++ b/Tests/IntegrationTests/HospitalManagementSystem.IntegrationTests/PatientsEndpointTests.cs
@@ -1,0 +1,12 @@
+using Xunit;
+
+namespace HospitalManagementSystem.IntegrationTests;
+
+public class PatientsEndpointTests
+{
+    [Fact(Skip = "Integration tests will be implemented once controllers are fully configured.")]
+    public void Placeholder()
+    {
+        // Integration tests for PatientsController will be added here.
+    }
+}

--- a/Tests/UnitTests/HospitalManagementSystem.UnitTests/CreatePatientCommandHandlerTests.cs
+++ b/Tests/UnitTests/HospitalManagementSystem.UnitTests/CreatePatientCommandHandlerTests.cs
@@ -1,0 +1,99 @@
+using AutoMapper;
+using FluentAssertions;
+using HospitalManagementSystem.Application.Common.Interfaces;
+using HospitalManagementSystem.Application.Common.Mappings;
+using HospitalManagementSystem.Application.Features.Patients.Commands.Create;
+using HospitalManagementSystem.Domain.Entities;
+using HospitalManagementSystem.Domain.Exceptions;
+using HospitalManagementSystem.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace HospitalManagementSystem.UnitTests;
+
+public class CreatePatientCommandHandlerTests
+{
+    private readonly IMapper _mapper;
+
+    public CreatePatientCommandHandlerTests()
+    {
+        var configuration = new MapperConfiguration(cfg => cfg.AddProfile<MappingProfile>());
+        _mapper = configuration.CreateMapper();
+    }
+
+    private IApplicationDbContext GetDbContext()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        return new TestApplicationDbContext(options);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldCreatePatient_WhenNewPatient()
+    {
+        var context = GetDbContext();
+        var handler = new CreatePatientCommandHandler(context, _mapper);
+
+        var command = new CreatePatientCommand
+        {
+            FirstName = "John",
+            LastName = "Doe",
+            DateOfBirth = new DateTime(1990, 1, 1),
+            Gender = "M",
+            ContactNumber = "1234567890",
+            Address = "123 Main St"
+        };
+
+        var id = await handler.Handle(command, CancellationToken.None);
+
+        var patient = await context.Patients.FindAsync(id);
+        patient.Should().NotBeNull();
+        patient!.PatientId.Should().Be(id);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldThrowDuplicateEntityException_WhenPatientExists()
+    {
+        var context = GetDbContext();
+        context.Patients.Add(new Patient
+        {
+            FirstName = "John",
+            LastName = "Doe",
+            DateOfBirth = new DateTime(1990, 1, 1),
+            Gender = "M",
+            ContactNumber = "1234567890",
+            Address = "123 Main St",
+            CreatedAt = DateTime.UtcNow,
+            IsActive = true
+        });
+        await context.SaveChangesAsync();
+
+        var handler = new CreatePatientCommandHandler(context, _mapper);
+
+        var command = new CreatePatientCommand
+        {
+            FirstName = "John",
+            LastName = "Doe",
+            DateOfBirth = new DateTime(1990, 1, 1),
+            Gender = "M",
+            ContactNumber = "1234567890",
+            Address = "123 Main St"
+        };
+
+        Func<Task> act = () => handler.Handle(command, CancellationToken.None);
+
+        await act.Should().ThrowAsync<DuplicateEntityException>();
+    }
+
+    private class TestApplicationDbContext : ApplicationDbContext, IApplicationDbContext
+    {
+        public TestApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : base(options) { }
+
+        public void MarkAsModified<TEntity>(TEntity entity) where TEntity : class =>
+            Entry(entity).State = EntityState.Modified;
+
+        public void MarkAsDeleted<TEntity>(TEntity entity) where TEntity : class =>
+            Entry(entity).State = EntityState.Deleted;
+    }
+}

--- a/Tests/UnitTests/HospitalManagementSystem.UnitTests/HospitalManagementSystem.UnitTests.csproj
+++ b/Tests/UnitTests/HospitalManagementSystem.UnitTests/HospitalManagementSystem.UnitTests.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="AutoFixture" Version="4.18.1" />
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.18.1" />
     <PackageReference Include="AutoFixture.Xunit2" Version="4.18.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.7" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
@@ -23,6 +24,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Application\HospitalManagementSystem.Application.csproj" />
+    <ProjectReference Include="..\..\..\Infrastructure\HospitalManagementSystem.Infrastructure.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- add DuplicateEntityException and stub DatabaseInitializer
- add CreatePatientCommandHandler unit tests for success and duplicate patient scenarios
- scaffold integration test project for API endpoints

## Testing
- `dotnet test` *(fails: `IRequestHandler<>` is ambiguous in Application project)*

------
https://chatgpt.com/codex/tasks/task_e_688dbadc6bdc83269ea82ddf5fbfff72