### PR TITLE
Add custom application identity user and role

### DIFF
--- a/Infrastructure/Data/ApplicationDbContext.cs
+++ b/Infrastructure/Data/ApplicationDbContext.cs
@@ -1,10 +1,12 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using HospitalManagementSystem.Domain.Entities;
 using HospitalManagementSystem.Application.Common.Interfaces;
+using HospitalManagementSystem.Infrastructure.Identity;
 
 namespace HospitalManagementSystem.Infrastructure.Data
 {
-    public class ApplicationDbContext : DbContext
+    public class ApplicationDbContext : IdentityDbContext<ApplicationUser, ApplicationRole, string>
     {
         private readonly ICurrentUserService _currentUserService;
 

--- a/Infrastructure/Identity/ApplicationRole.cs
+++ b/Infrastructure/Identity/ApplicationRole.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Identity;
+
+namespace HospitalManagementSystem.Infrastructure.Identity
+{
+    /// <summary>
+    /// Custom application role extending the default IdentityRole.
+    /// </summary>
+    public class ApplicationRole : IdentityRole
+    {
+        /// <summary>
+        /// Gets or sets a brief description of the role.
+        /// </summary>
+        public string? Description { get; set; }
+    }
+}

--- a/Infrastructure/Identity/ApplicationUser.cs
+++ b/Infrastructure/Identity/ApplicationUser.cs
@@ -1,0 +1,25 @@
+using Microsoft.AspNetCore.Identity;
+
+namespace HospitalManagementSystem.Infrastructure.Identity
+{
+    /// <summary>
+    /// Custom application user that extends the default IdentityUser.
+    /// </summary>
+    public class ApplicationUser : IdentityUser
+    {
+        /// <summary>
+        /// Gets or sets the user's first name.
+        /// </summary>
+        public string? FirstName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the user's last name.
+        /// </summary>
+        public string? LastName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the user's date of birth.
+        /// </summary>
+        public DateOnly? DateOfBirth { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- add `ApplicationUser` identity model with profile properties
- add `ApplicationRole` model to support role descriptions
- update `ApplicationDbContext` to use Identity

## Testing
- `dotnet build HospitalManagementSystem.sln` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_688ed37d47248326aaef5179b6bd79a0