### PR TITLE
Add .NET Aspire AppHost

### DIFF
--- a/AppHost/AppHost.csproj
+++ b/AppHost/AppHost.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsAspireComponent>true</IsAspireComponent>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Aspire.Hosting" Version="9.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\\WebAPI\\HospitalManagementSystem.WebAPI.csproj" />
+    <ProjectReference Include="..\\WebApp\\HospitalManagementSystem.WebApp.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/AppHost/Program.cs
+++ b/AppHost/Program.cs
@@ -1,0 +1,10 @@
+using Aspire.Hosting;
+
+var builder = DistributedApplication.CreateBuilder(args);
+
+var api = builder.AddProject("webapi", "../WebAPI/HospitalManagementSystem.WebAPI.csproj");
+var web = builder.AddProject("webapp", "../WebApp/HospitalManagementSystem.WebApp.csproj")
+                 .WithReference(api);
+
+builder.Build().Run();
+

--- a/HospitalManagementSystem.sln
+++ b/HospitalManagementSystem.sln
@@ -37,6 +37,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "FunctionalTests", "Function
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HospitalManagementSystem.FunctionalTests", "Tests\FunctionalTests\HospitalManagementSystem.FunctionalTests\HospitalManagementSystem.FunctionalTests.csproj", "{608230C6-B19F-4807-913F-84FACA1E0F1A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AppHost", "AppHost\AppHost.csproj", "{106602F6-82D7-44DB-808F-0746DE5B676D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -143,6 +145,18 @@ Global
 		{608230C6-B19F-4807-913F-84FACA1E0F1A}.Release|x64.Build.0 = Release|Any CPU
 		{608230C6-B19F-4807-913F-84FACA1E0F1A}.Release|x86.ActiveCfg = Release|Any CPU
 		{608230C6-B19F-4807-913F-84FACA1E0F1A}.Release|x86.Build.0 = Release|Any CPU
+		{106602F6-82D7-44DB-808F-0746DE5B676D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{106602F6-82D7-44DB-808F-0746DE5B676D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{106602F6-82D7-44DB-808F-0746DE5B676D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{106602F6-82D7-44DB-808F-0746DE5B676D}.Debug|x64.Build.0 = Debug|Any CPU
+		{106602F6-82D7-44DB-808F-0746DE5B676D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{106602F6-82D7-44DB-808F-0746DE5B676D}.Debug|x86.Build.0 = Debug|Any CPU
+		{106602F6-82D7-44DB-808F-0746DE5B676D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{106602F6-82D7-44DB-808F-0746DE5B676D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{106602F6-82D7-44DB-808F-0746DE5B676D}.Release|x64.ActiveCfg = Release|Any CPU
+		{106602F6-82D7-44DB-808F-0746DE5B676D}.Release|x64.Build.0 = Release|Any CPU
+		{106602F6-82D7-44DB-808F-0746DE5B676D}.Release|x86.ActiveCfg = Release|Any CPU
+		{106602F6-82D7-44DB-808F-0746DE5B676D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- add Aspire AppHost project to orchestrate WebAPI and WebApp services
- wire AppHost into solution for unified launch experience

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_688f102271cc8326ac3ea7cad69da7da