### PR TITLE
Use component reference for MudThemeProvider

### DIFF
--- a/WebApp/Components/Layout/MainLayout.razor
+++ b/WebApp/Components/Layout/MainLayout.razor
@@ -1,6 +1,5 @@
 ﻿@inherits LayoutComponentBase
-@inject MudThemeProvider MudThemeProvider
-
+<MudThemeProvider @ref="_themeProvider" />
 <MudLayout>
 	<MudAppBar Elevation="0" Color="Color.Primary">
 		<MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="ToggleDrawer" />
@@ -15,7 +14,8 @@
 </MudLayout>
 
 @code {
-	private bool _drawerOpen = true;
+        private MudThemeProvider? _themeProvider;
+        private bool _drawerOpen = true;
 	// private MudTheme _theme = new MudTheme()
 	// {
 	// 	PaletteDark = new PaletteDark()
@@ -30,6 +30,6 @@
 	protected override async Task OnInitializedAsync()
 	{
 		// Apply your theme
-		// MudThemeProvider.Theme = _theme;
-	}
+                // _themeProvider!.Theme = _theme;
+        }
 }


### PR DESCRIPTION
## Summary
- replace injected MudThemeProvider with component reference
- add theme provider field and adjust theme application comment

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_688f2fb7543c8326b5a7e87f5585876c