### PR TITLE
Implement JWT authentication and front-end login

### DIFF
--- a/Infrastructure/Data/DatabaseInitializer.cs
+++ b/Infrastructure/Data/DatabaseInitializer.cs
@@ -1,12 +1,50 @@
-using System.Threading.Tasks;
+using HospitalManagementSystem.Infrastructure.Identity;
+using Microsoft.AspNetCore.Identity;
 
-namespace HospitalManagementSystem.Infrastructure.Data
+namespace HospitalManagementSystem.Infrastructure.Data;
+
+/// <summary>
+/// Seeds initial data for the application, including a default super administrator user.
+/// </summary>
+public class DatabaseInitializer
 {
-    public class DatabaseInitializer
+    private readonly RoleManager<ApplicationRole> _roleManager;
+    private readonly UserManager<ApplicationUser> _userManager;
+
+    public DatabaseInitializer(RoleManager<ApplicationRole> roleManager, UserManager<ApplicationUser> userManager)
     {
-        public Task InitializeAsync()
+        _roleManager = roleManager;
+        _userManager = userManager;
+    }
+
+    /// <summary>
+    /// Ensures that essential roles and the default super administrator user exist.
+    /// </summary>
+    public async Task InitializeAsync()
+    {
+        const string adminRole = "Administrator";
+        const string adminUser = "superadmin";
+        const string adminEmail = "superadmin@example.com";
+        const string adminPassword = "SuperAdmin123!";
+
+        if (!await _roleManager.RoleExistsAsync(adminRole))
         {
-            return Task.CompletedTask;
+            var role = new ApplicationRole { Name = adminRole, Description = "System administrator" };
+            await _roleManager.CreateAsync(role);
+        }
+
+        var user = await _userManager.FindByNameAsync(adminUser);
+        if (user == null)
+        {
+            user = new ApplicationUser
+            {
+                UserName = adminUser,
+                Email = adminEmail,
+                EmailConfirmed = true
+            };
+
+            await _userManager.CreateAsync(user, adminPassword);
+            await _userManager.AddToRoleAsync(user, adminRole);
         }
     }
 }

--- a/WebAPI/Controllers/AuthenticationController.cs
+++ b/WebAPI/Controllers/AuthenticationController.cs
@@ -1,0 +1,53 @@
+using HospitalManagementSystem.Infrastructure.Identity;
+using HospitalManagementSystem.WebAPI.Models.Authentication;
+using HospitalManagementSystem.WebAPI.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+
+namespace HospitalManagementSystem.WebAPI.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class AuthenticationController : ControllerBase
+{
+    private readonly UserManager<ApplicationUser> _userManager;
+    private readonly SignInManager<ApplicationUser> _signInManager;
+    private readonly ITokenService _tokenService;
+
+    public AuthenticationController(UserManager<ApplicationUser> userManager, SignInManager<ApplicationUser> signInManager, ITokenService tokenService)
+    {
+        _userManager = userManager;
+        _signInManager = signInManager;
+        _tokenService = tokenService;
+    }
+
+    [AllowAnonymous]
+    [HttpPost("register")]
+    public async Task<IActionResult> Register(RegisterRequest request)
+    {
+        var user = new ApplicationUser { UserName = request.Username, Email = request.Email };
+        var result = await _userManager.CreateAsync(user, request.Password!);
+        if (!result.Succeeded)
+        {
+            return BadRequest(result.Errors);
+        }
+        return Ok();
+    }
+
+    [AllowAnonymous]
+    [HttpPost("login")]
+    public async Task<IActionResult> Login(LoginRequest request)
+    {
+        var user = await _userManager.FindByNameAsync(request.Username!);
+        if (user == null)
+            return Unauthorized();
+
+        var result = await _signInManager.CheckPasswordSignInAsync(user, request.Password!, false);
+        if (!result.Succeeded)
+            return Unauthorized();
+
+        var token = await _tokenService.CreateToken(user);
+        return Ok(new { Token = token });
+    }
+}

--- a/WebAPI/Models/Authentication/LoginRequest.cs
+++ b/WebAPI/Models/Authentication/LoginRequest.cs
@@ -1,0 +1,7 @@
+namespace HospitalManagementSystem.WebAPI.Models.Authentication;
+
+public class LoginRequest
+{
+    public string? Username { get; set; }
+    public string? Password { get; set; }
+}

--- a/WebAPI/Models/Authentication/RegisterRequest.cs
+++ b/WebAPI/Models/Authentication/RegisterRequest.cs
@@ -1,0 +1,8 @@
+namespace HospitalManagementSystem.WebAPI.Models.Authentication;
+
+public class RegisterRequest
+{
+    public string? Username { get; set; }
+    public string? Email { get; set; }
+    public string? Password { get; set; }
+}

--- a/WebAPI/Program.cs
+++ b/WebAPI/Program.cs
@@ -23,6 +23,8 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddControllers();
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddScoped<ICurrentUserService, CurrentUserService>();
+builder.Services.AddScoped<ITokenService, TokenService>();
+builder.Services.AddScoped<DatabaseInitializer>();
 
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
@@ -169,11 +171,10 @@ using (var scope = app.Services.CreateScope())
 {
     var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
     context.Database.Migrate();
-    
-    //var initializer = scope.ServiceProvider.GetRequiredService<DatabaseInitializer>();
-    //await initializer.InitializeAsync();
+    var initializer = scope.ServiceProvider.GetRequiredService<DatabaseInitializer>();
+    await initializer.InitializeAsync();
 }
 
-app.Run();
+await app.RunAsync();
 
 

--- a/WebAPI/Services/ITokenService.cs
+++ b/WebAPI/Services/ITokenService.cs
@@ -1,0 +1,8 @@
+using HospitalManagementSystem.Infrastructure.Identity;
+
+namespace HospitalManagementSystem.WebAPI.Services;
+
+public interface ITokenService
+{
+    Task<string> CreateToken(ApplicationUser user);
+}

--- a/WebAPI/Services/TokenService.cs
+++ b/WebAPI/Services/TokenService.cs
@@ -1,0 +1,45 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using HospitalManagementSystem.Infrastructure.Identity;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Configuration;
+using Microsoft.IdentityModel.Tokens;
+
+namespace HospitalManagementSystem.WebAPI.Services;
+
+public class TokenService : ITokenService
+{
+    private readonly IConfiguration _configuration;
+    private readonly UserManager<ApplicationUser> _userManager;
+
+    public TokenService(IConfiguration configuration, UserManager<ApplicationUser> userManager)
+    {
+        _configuration = configuration;
+        _userManager = userManager;
+    }
+
+    public async Task<string> CreateToken(ApplicationUser user)
+    {
+        var authClaims = new List<Claim>
+        {
+            new Claim(ClaimTypes.NameIdentifier, user.Id),
+            new Claim(ClaimTypes.Name, user.UserName ?? string.Empty)
+        };
+
+        var roles = await _userManager.GetRolesAsync(user);
+        authClaims.AddRange(roles.Select(role => new Claim(ClaimTypes.Role, role)));
+
+        var authSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_configuration["Jwt:Key"]!));
+
+        var token = new JwtSecurityToken(
+            issuer: _configuration["Jwt:Issuer"],
+            audience: _configuration["Jwt:Audience"],
+            expires: DateTime.UtcNow.AddHours(1),
+            claims: authClaims,
+            signingCredentials: new SigningCredentials(authSigningKey, SecurityAlgorithms.HmacSha256)
+        );
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+}

--- a/WebApp/Components/Layout/NavMenu.razor
+++ b/WebApp/Components/Layout/NavMenu.razor
@@ -1,4 +1,5 @@
 <MudNavMenu>
     <MudNavLink Href="/" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Home">Dashboard</MudNavLink>
     <MudNavLink Href="/patients" Icon="@Icons.Material.Filled.People">Patients</MudNavLink>
+    <MudNavLink Href="/login" Icon="@Icons.Material.Filled.Login">Login</MudNavLink>
 </MudNavMenu>

--- a/WebApp/Models/LoginModel.cs
+++ b/WebApp/Models/LoginModel.cs
@@ -1,0 +1,7 @@
+namespace HospitalManagementSystem.WebApp.Models;
+
+public class LoginModel
+{
+    public string? Username { get; set; }
+    public string? Password { get; set; }
+}

--- a/WebApp/Pages/Login.razor
+++ b/WebApp/Pages/Login.razor
@@ -1,0 +1,33 @@
+@page "/login"
+@using HospitalManagementSystem.WebApp.Models
+@inject IAuthService AuthService
+@inject NavigationManager NavigationManager
+
+<h3>Login</h3>
+
+<EditForm Model="loginModel" OnValidSubmit="HandleLogin">
+    <DataAnnotationsValidator />
+    <ValidationSummary />
+    <div class="mb-3">
+        <label>Username</label>
+        <InputText @bind-Value="loginModel.Username" class="form-control" />
+    </div>
+    <div class="mb-3">
+        <label>Password</label>
+        <InputText @bind-Value="loginModel.Password" type="password" class="form-control" />
+    </div>
+    <button type="submit" class="btn btn-primary">Login</button>
+</EditForm>
+
+@code {
+    private LoginModel loginModel = new();
+
+    private async Task HandleLogin()
+    {
+        var success = await AuthService.LoginAsync(loginModel.Username!, loginModel.Password!);
+        if (success)
+        {
+            NavigationManager.NavigateTo("/");
+        }
+    }
+}

--- a/WebApp/Program.cs
+++ b/WebApp/Program.cs
@@ -11,10 +11,12 @@ builder.Services.AddHttpContextAccessor();
 builder.Services.AddScoped<ICurrentUserService, CurrentUserService>();
 
 // Register HTTP client for API calls
-builder.Services.AddHttpClient<IPatientService, PatientService>(client =>
+builder.Services.AddScoped(sp => new HttpClient
 {
-    client.BaseAddress = new Uri(builder.Configuration["ApiBaseUrl"] ?? "https://localhost:7123/");
+    BaseAddress = new Uri(builder.Configuration["ApiBaseUrl"] ?? "https://localhost:7123/")
 });
+builder.Services.AddScoped<IPatientService, PatientService>();
+builder.Services.AddScoped<IAuthService, AuthService>();
 
 var app = builder.Build();
 

--- a/WebApp/Services/AuthService.cs
+++ b/WebApp/Services/AuthService.cs
@@ -1,0 +1,47 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using HospitalManagementSystem.WebApp.Models;
+
+namespace HospitalManagementSystem.WebApp.Services;
+
+public class AuthService : IAuthService
+{
+    private readonly HttpClient _httpClient;
+    public string? Token { get; private set; }
+
+    public AuthService(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public async Task<bool> LoginAsync(string username, string password)
+    {
+        var response = await _httpClient.PostAsJsonAsync("api/authentication/login", new LoginModel { Username = username, Password = password });
+        if (!response.IsSuccessStatusCode)
+        {
+            return false;
+        }
+
+        var result = await response.Content.ReadFromJsonAsync<LoginResponse>();
+        if (result?.Token == null)
+        {
+            return false;
+        }
+
+        Token = result.Token;
+        _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+        return true;
+    }
+
+    public Task LogoutAsync()
+    {
+        Token = null;
+        _httpClient.DefaultRequestHeaders.Authorization = null;
+        return Task.CompletedTask;
+    }
+
+    private class LoginResponse
+    {
+        public string? Token { get; set; }
+    }
+}

--- a/WebApp/Services/IAuthService.cs
+++ b/WebApp/Services/IAuthService.cs
@@ -1,0 +1,7 @@
+namespace HospitalManagementSystem.WebApp.Services;
+
+public interface IAuthService
+{
+    Task<bool> LoginAsync(string username, string password);
+    Task LogoutAsync();
+}

--- a/WebApp/_Imports.razor
+++ b/WebApp/_Imports.razor
@@ -8,4 +8,6 @@
 @using Microsoft.JSInterop
 @using HospitalManagementSystem.WebApp
 @using HospitalManagementSystem.WebApp.Components.Layout
+@using HospitalManagementSystem.WebApp.Models
+@using HospitalManagementSystem.WebApp.Services
 @using MudBlazor


### PR DESCRIPTION
## Summary
- add authentication controller with login and registration endpoints
- generate JWT tokens with new TokenService
- add Blazor login page and authentication service for API access
- seed Administrator role and default superadmin user at startup

## Testing
- `dotnet build WebAPI/HospitalManagementSystem.WebAPI.csproj`
- `dotnet build WebApp/HospitalManagementSystem.WebApp.csproj`
- `dotnet test Tests/UnitTests/HospitalManagementSystem.UnitTests/HospitalManagementSystem.UnitTests.csproj` (fails: Required properties are missing)
- `dotnet test Tests/FunctionalTests/HospitalManagementSystem.FunctionalTests/HospitalManagementSystem.FunctionalTests.csproj`
- `dotnet test Tests/IntegrationTests/HospitalManagementSystem.IntegrationTests/HospitalManagementSystem.IntegrationTests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_688f3d91334c8326bf86f731b90ac883