### PR TITLE
feat: seed development database with sample data

### DIFF
--- a/Infrastructure/Data/DatabaseInitializer.cs
+++ b/Infrastructure/Data/DatabaseInitializer.cs
@@ -1,5 +1,9 @@
 using HospitalManagementSystem.Infrastructure.Identity;
 using Microsoft.AspNetCore.Identity;
+using HospitalManagementSystem.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Linq;
 
 namespace HospitalManagementSystem.Infrastructure.Data;
 
@@ -10,11 +14,13 @@ public class DatabaseInitializer
 {
     private readonly RoleManager<ApplicationRole> _roleManager;
     private readonly UserManager<ApplicationUser> _userManager;
+    private readonly ApplicationDbContext _context;
 
-    public DatabaseInitializer(RoleManager<ApplicationRole> roleManager, UserManager<ApplicationUser> userManager)
+    public DatabaseInitializer(RoleManager<ApplicationRole> roleManager, UserManager<ApplicationUser> userManager, ApplicationDbContext context)
     {
         _roleManager = roleManager;
         _userManager = userManager;
+        _context = context;
     }
 
     /// <summary>
@@ -45,6 +51,89 @@ public class DatabaseInitializer
 
             await _userManager.CreateAsync(user, adminPassword);
             await _userManager.AddToRoleAsync(user, adminRole);
+        }
+    }
+
+    /// <summary>
+    /// Seeds sample data for development environment.
+    /// </summary>
+    public async Task SeedDevelopmentDataAsync()
+    {
+        if (!_context.Departments.Any())
+        {
+            var cardiology = new Department
+            {
+                Name = "Cardiology",
+                Description = "Heart related services",
+                Location = "Building A"
+            };
+
+            var neurology = new Department
+            {
+                Name = "Neurology",
+                Description = "Brain and nerves",
+                Location = "Building B"
+            };
+
+            _context.Departments.AddRange(cardiology, neurology);
+            await _context.SaveChangesAsync();
+        }
+
+        if (!_context.Doctors.Any())
+        {
+            var department = _context.Departments.First();
+
+            var doctor = new Doctor
+            {
+                FirstName = "John",
+                LastName = "Doe",
+                Specialization = "Cardiology",
+                LicenseNumber = "DOC123456",
+                ContactNumber = "555-0000",
+                Email = "john.doe@example.com",
+                DepartmentId = department.DepartmentId
+            };
+
+            _context.Doctors.Add(doctor);
+            await _context.SaveChangesAsync();
+        }
+
+        if (!_context.Patients.Any())
+        {
+            var patient = new Patient
+            {
+                FirstName = "Jane",
+                LastName = "Smith",
+                DateOfBirth = new DateTime(1990, 5, 20),
+                Gender = "F",
+                ContactNumber = "555-1111",
+                Address = "123 Main St",
+                Email = "jane.smith@example.com"
+            };
+
+            _context.Patients.Add(patient);
+            await _context.SaveChangesAsync();
+        }
+
+        if (!_context.Appointments.Any())
+        {
+            var doctor = _context.Doctors.First();
+            var patient = _context.Patients.First();
+
+            var appointmentDate = DateTime.UtcNow.AddDays(1);
+
+            var appointment = new Appointment
+            {
+                DoctorId = doctor.DoctorId,
+                PatientId = patient.PatientId,
+                AppointmentDate = appointmentDate,
+                EndTime = appointmentDate.AddHours(1),
+                Purpose = "General Checkup",
+                Status = "Scheduled"
+            };
+
+            _context.Appointments.Add(appointment);
+            await _context.SaveChangesAsync();
         }
     }
 }

--- a/WebAPI/Program.cs
+++ b/WebAPI/Program.cs
@@ -173,6 +173,10 @@ using (var scope = app.Services.CreateScope())
     context.Database.Migrate();
     var initializer = scope.ServiceProvider.GetRequiredService<DatabaseInitializer>();
     await initializer.InitializeAsync();
+    if (app.Environment.IsDevelopment())
+    {
+        await initializer.SeedDevelopmentDataAsync();
+    }
 }
 
 await app.RunAsync();


### PR DESCRIPTION
## Summary
- seed departments, doctors, patients and appointments during development
- invoke development seeding from the API startup

## Testing
- `dotnet test` *(fails: Required properties {'BloodGroup', 'Email', 'EmergencyContact', 'MedicalHistory', 'UpdatedBy'} are missing for the instance of entity type 'Patient')*
- `dotnet test Tests/UnitTests/HospitalManagementSystem.UnitTests/HospitalManagementSystem.UnitTests.csproj` *(fails: Required properties {'BloodGroup', 'Email', 'EmergencyContact', 'MedicalHistory', 'UpdatedBy'} are missing for the instance of entity type 'Patient')*

------
https://chatgpt.com/codex/tasks/task_e_688f4fe98d3c8326b86494fca17ea45b