### PR TITLE
Align AutoMapper package versions

### DIFF
--- a/Application/HospitalManagementSystem.Application.csproj
+++ b/Application/HospitalManagementSystem.Application.csproj
@@ -5,7 +5,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="15.0.1" />
+    <PackageReference Include="AutoMapper" Version="12.0.1" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
     <PackageReference Include="FluentValidation" Version="12.0.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />

--- a/WebAPI/HospitalManagementSystem.WebAPI.csproj
+++ b/WebAPI/HospitalManagementSystem.WebAPI.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="15.0.1" />
+    <PackageReference Include="AutoMapper" Version="12.0.1" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />
     <PackageReference Include="Hangfire" Version="1.8.20" />


### PR DESCRIPTION
## Summary
- ensure AutoMapper and AutoMapper.Extensions.Microsoft.DependencyInjection use matching 12.x versions in Application and WebAPI projects

## Testing
- `dotnet restore WebAPI/HospitalManagementSystem.WebAPI.csproj`
- `dotnet build WebAPI/HospitalManagementSystem.WebAPI.csproj`


------
https://chatgpt.com/codex/tasks/task_e_688f5af4be088326ae91487aefe2da4e